### PR TITLE
feat: load DLC bundles on startup

### DIFF
--- a/src/BmSDK/FrameworkInternal/DLCManager.cs
+++ b/src/BmSDK/FrameworkInternal/DLCManager.cs
@@ -1,0 +1,60 @@
+using BmSDK.BmGame;
+using BmSDK.Engine;
+
+namespace BmSDK.Framework;
+
+/// <summary>
+/// Scans the game's DLC directory and installs every bundle found there on startup.
+/// </summary>
+internal static class DLCManager
+{
+    [UnmanagedFunctionPointer(CallingConvention.ThisCall)]
+    private delegate void InstallBundleDelegate(IntPtr self, IntPtr dlcBundle);
+
+    public static unsafe void Run()
+    {
+        var engine = Game.GetEngine();
+
+        var enumerator = engine.DLCEnumerator;
+        if (enumerator is null)
+        {
+            enumerator = new DownloadableContentEnumerator(engine);
+            engine.DLCEnumerator = enumerator;
+        }
+
+        // Native scan of DLCRootDir ("../../DLC/"), one bundle per subdirectory
+        enumerator.FindDLC();
+
+        var manager = engine.DLCManager;
+        if (manager is null)
+        {
+            manager = new RDownloadableContentManager(engine);
+            engine.DLCManager = manager;
+        }
+
+        // Grab native functions from vtable (slightly more portable than regular offsets)
+        var vtable = *(IntPtr*)manager.Ptr;
+        var installPackages = Marshal.GetDelegateForFunctionPointer<InstallBundleDelegate>(
+            *(IntPtr*)(vtable + GameDefine.VTableOffsets.DownloadableContentManager__InstallPackages)
+        );
+        var installNonPackageFiles = Marshal.GetDelegateForFunctionPointer<InstallBundleDelegate>(
+            *(IntPtr*)(
+                vtable + GameDefine.VTableOffsets.DownloadableContentManager__InstallNonPackageFiles
+            )
+        );
+
+        var bundles = enumerator.DLCBundles;
+        for (var i = 0; i < bundles.Count; i++)
+        {
+            // The native element, not the managed copy the indexer hands back
+            var bundlePtr = bundles.Data.AllocatorInstance + (i * bundles.Stride);
+            var name = bundles[i].FriendlyName.ToString() ?? string.Empty;
+
+            Debug.Log($"Installing DLC bundle '{name}'");
+            installPackages(manager.Ptr, bundlePtr);
+            installNonPackageFiles(manager.Ptr, bundlePtr);
+
+            manager.InstalledDLC.Push(name);
+        }
+    }
+}

--- a/src/BmSDK/FrameworkInternal/GameDefine.Epic.cs
+++ b/src/BmSDK/FrameworkInternal/GameDefine.Epic.cs
@@ -1,6 +1,6 @@
 namespace BmSDK.Framework;
 
-internal sealed class GameDefineEpic : GameDefine
+public sealed class GameDefineEpic : GameDefine
 {
     public const uint TimeDateStamp = 0x5D9F84DF;
 

--- a/src/BmSDK/FrameworkInternal/GameDefine.Steam.cs
+++ b/src/BmSDK/FrameworkInternal/GameDefine.Steam.cs
@@ -1,6 +1,6 @@
 namespace BmSDK.Framework;
 
-internal sealed class GameDefineSteam : GameDefine
+public sealed class GameDefineSteam : GameDefine
 {
     public const uint TimeDateStamp = 0x520000F7;
 

--- a/src/BmSDK/FrameworkInternal/GameDefine.cs
+++ b/src/BmSDK/FrameworkInternal/GameDefine.cs
@@ -1,6 +1,6 @@
 namespace BmSDK.Framework;
 
-internal abstract class GameDefine
+public abstract class GameDefine
 {
     private static GameDefine? s_current = null;
 
@@ -57,6 +57,13 @@ internal abstract class GameDefine
         public const IntPtr Object__Class = 36;
         public const IntPtr Struct__SuperStruct = 56;
         public const IntPtr Class__ClassFlags = 180;
+    }
+
+    // Identical across builds, so not per-define
+    public static class VTableOffsets
+    {
+        public const IntPtr DownloadableContentManager__InstallPackages = 340;
+        public const IntPtr DownloadableContentManager__InstallNonPackageFiles = 344;
     }
 
     // Identifies the build from the PE header's TimeDateStamp

--- a/src/BmSDK/Loader.cs
+++ b/src/BmSDK/Loader.cs
@@ -105,6 +105,9 @@ internal static class Loader
             // Notify scripts of game init
             if (!s_hasGameInited && funcName == InitFuncName)
             {
+                // Install DLC bundles
+                DLCManager.Run();
+
                 // Preload packages and root keep-alive objects before any world loads
                 PreloadManager.Run();
 


### PR DESCRIPTION
Also makes `GameDefine` public, allowing code like:
```cs
if (GameDefine.Current is GameDefineEpic)
{
  ...do EGS-specific thing
}
```